### PR TITLE
spring security依赖包位置变动

### DIFF
--- a/cc-user-auth-service/pom.xml
+++ b/cc-user-auth-service/pom.xml
@@ -11,6 +11,13 @@
 
     <artifactId>cc-user-auth-service</artifactId>
 
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+    </dependencies>
+
     <build>
         <plugins>
             <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -45,10 +45,6 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-security</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
 


### PR DESCRIPTION
spring security应该只放在user-auth中。
不然放在根pom文件中，会使得其他项目的所有api默认受到basic认证管控，从而无法正常访问。